### PR TITLE
add-task-category

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,12 +11,25 @@
   </header>
 
   <main>
-    <section id="tasks">
-      <h2>やること一覧</h2>
+    <section id="tasks work">
+      <h2>未完了タスク</h2>
       <ul>
         <li>レポートを提出する</li>
-        <li>部屋を片付ける</li>
         <li>メールを確認する</li>
+      </ul>
+    </section>
+
+    <section id="tasks private">
+      <h2>未完了タスク</h2>
+      <ul>
+        <li>部屋を片付ける</li>
+      </ul>
+    </section>
+
+    <section id="completion">
+      <h2>完了済み</h2>
+      <ul>
+        <li>ゴミ出し</li>
       </ul>
     </section>
   </main>


### PR DESCRIPTION
index.htmlメイン部分に「完了済み」タスク用の新しいセクションを追加
新しいセクションには、例として「ゴミ出し」というタスクを1件追加
既存の「やること一覧」セクションは「未完了タスク」と名称変更し、タスクを「仕事」「プライベート」の2カテゴリに分割
既存タスクを適切に振り分けること